### PR TITLE
Refactor createTempDirectory method to use java.nio.file.Files

### DIFF
--- a/eclipse-language-servers/org.springsource.ide.eclipse.commons.frameworks.core/src/org/springsource/ide/eclipse/commons/frameworks/core/util/FileUtil.java
+++ b/eclipse-language-servers/org.springsource.ide.eclipse.commons.frameworks.core/src/org/springsource/ide/eclipse/commons/frameworks/core/util/FileUtil.java
@@ -12,7 +12,8 @@ package org.springsource.ide.eclipse.commons.frameworks.core.util;
 
 import java.io.File;
 import java.io.IOException;
-
+import java.nio.file.Files;
+import java.nio.file.Path;
 /**
  * @author Steffen Pingel
  * @author Leo Dos Santos
@@ -56,13 +57,8 @@ public class FileUtil {
 	 * @throws IOException
 	 */
 	public static File createTempDirectory(String name, String suffix) throws IOException {
-		File tempFolder = File.createTempFile(name, suffix);
-		if (!tempFolder.delete()) {
-			throw new IOException("Could not delete temp file: " + tempFolder.getAbsolutePath());
-		}
-		if (!tempFolder.mkdirs()) {
-			throw new IOException("Could not create temp directory: " + tempFolder.getAbsolutePath());
-		}
+		String tempDirPrefix = (name != null ? name : "") + (suffix != null ? suffix : "");
+    	File tempFolder = Files.createTempDirectory(tempDirPrefix).toFile();
 		deleteOnShutdown(tempFolder);
 		return tempFolder;
 	}


### PR DESCRIPTION
## Description 
This PR refactor createTempDirectory method in FileUtil.java to use java.nio.file.Files. 
The previous approach required manual handling of temporary file deletion and directory creation, could also pose a security vulnerability (CWE-379). The NIO-based method is more atomic and cleaner.

Changes made:
- Replaced use of `File.createTempFile`, `delete()`, and `mkdirs()` with `Files.createTempDirectory`.
- Updated imports to use `java.nio.file.Path` and `Files`.

References 
https://github.com/UniversaBlockchain/universa/commit/1e34b1804842a7a2ba27fa9f4210a6fcb340d517
https://www.cve.org/CVERecord?id=CVE-2022-27772

Thanks for taking the time to review!