### PR TITLE
Allow disabling named interface grouping via system property.

### DIFF
--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/commands/ApplicationModule.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/commands/ApplicationModule.java
@@ -46,5 +46,11 @@ public class ApplicationModule {
 	public Collection<NamedInterface> getNamedInterfaces() {
 		return appModule.namedInterfaces();
 	}
-
+	
+	public boolean isExposed(String type) {
+		
+		return appModule.namedInterfaces().stream()
+				.flatMap(it -> it.getClasses().stream())
+				.anyMatch(type::equals);
+	}
 }

--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/commands/ApplicationModulesLabelProvider.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/commands/ApplicationModulesLabelProvider.java
@@ -59,11 +59,18 @@ public class ApplicationModulesLabelProvider implements
 	@Override
 	public String getTypeLabel(StereotypeClassElement type) {
 
-		return modules.getModuleByType(type)
+		var result = modules.getModuleByType(type)
 				.map(it -> it.getBasePackage())
 				.map(it -> new StereotypePackageElement(it, Collections.emptySet()))
 				.map(it -> StructureViewUtil.abbreviate(it, type))
 				.orElseGet(type::getType);
+
+		return "true".equals(System.getProperty("disable-named-interfaces"))
+				? result + modules.getModuleByType(type)
+						.filter(it -> it.isExposed(type.getType()))
+						.map(__ -> " (API)")
+						.orElse(" (internal)")
+				: result;
 	}
 
 	@Override

--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/commands/ApplicationModulesStructureProvider.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/commands/ApplicationModulesStructureProvider.java
@@ -42,5 +42,19 @@ public abstract class ApplicationModulesStructureProvider
 	public Collection<StereotypeMethodElement> extractMethods(StereotypeClassElement type) {
 		return type.getMethods();
 	}
+	
+	static class SimpleApplicationModulesStructureProvider extends ApplicationModulesStructureProvider implements SimpleStructureProvider<ApplicationModules, StereotypePackageElement, StereotypeClassElement, StereotypeMethodElement> {
 
+		SimpleApplicationModulesStructureProvider(IJavaProject project, SpringMetamodelIndex springIndex) {
+			super(project, springIndex);
+		}
+
+		@Override
+		public Collection<StereotypeClassElement> extractTypes(StereotypePackageElement pkg) {
+			
+			return springIndex.getNodesOfType(project.getElementName(), StereotypeClassElement.class).stream()
+					.filter(element -> element.getType().startsWith(pkg.getPackageName()))
+					.toList();
+		}
+	}
 }

--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/commands/ModulithStructureView.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/commands/ModulithStructureView.java
@@ -16,6 +16,8 @@ import java.util.function.BiConsumer;
 import org.jmolecules.stereotype.catalog.support.AbstractStereotypeCatalog;
 import org.jmolecules.stereotype.tooling.HierarchicalNodeHandler;
 import org.jmolecules.stereotype.tooling.ProjectTree;
+import org.springframework.ide.vscode.boot.index.SpringMetamodelIndex;
+import org.springframework.ide.vscode.boot.java.commands.ApplicationModulesStructureProvider.SimpleApplicationModulesStructureProvider;
 import org.springframework.ide.vscode.boot.java.commands.JsonNodeHandler.Node;
 import org.springframework.ide.vscode.boot.java.stereotypes.IndexBasedStereotypeFactory;
 import org.springframework.ide.vscode.boot.modulith.AppModules;
@@ -43,11 +45,12 @@ public class ModulithStructureView {
 			// TODO; logging
 			return null;
 		}
-		
+
 		ApplicationModules modules = new ApplicationModules(modulesData);
-		
+
 		var labelProvider = new ApplicationModulesLabelProvider(catalog, project, springIndex, modules);
-		var structureProvider = new ApplicationModulesNamedInterfacesGroupingProvider(modules, project, springIndex);
+		
+		
 
 		// json output
 		BiConsumer<Node, NamedInterfaceNode> consumer = (node, c) -> {
@@ -60,8 +63,13 @@ public class ModulithStructureView {
 
 		// create the project tree and apply all the groupers from the project
 		// TODO: in the future, we need to trim this grouper arrays down to what is selected on the UI
-		var jsonTree = new ProjectTree<>(adapter, catalog, jsonHandler)
-				.withStructureProvider(structureProvider);
+		var jsonTree = new ProjectTree<>(adapter, catalog, jsonHandler);
+
+		if ("true".equals(System.getProperty("disable-named-interfaces"))) {
+			jsonTree = jsonTree.withStructureProvider(new SimpleApplicationModulesStructureProvider(project, springIndex));
+		} else {
+			jsonTree = jsonTree.withStructureProvider(new ApplicationModulesNamedInterfacesGroupingProvider(modules, project, springIndex));
+		}
 
 		List<String[]> groupers = StructureViewUtil.identifyGroupers(catalog, selectedGroups);
 		for (String[] grouper : groupers) {
@@ -72,5 +80,4 @@ public class ModulithStructureView {
 
 		return jsonHandler.getRoot();
 	}
-
 }


### PR DESCRIPTION
We now allow disabling the named interfaces grouping via a disable-named-interfaces system property for the Language Server. If this is activated, the type labels are now additionally decorated with an "API" / "internal" extension to indicate, whether they are accessible to other modules.
